### PR TITLE
Dockerのコンテナと、そこでテストを書く為の最低限の依存切り

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9.13-buster
+LABEL maintainer="hogeika2@gmail.com"
+LABEL version="1.0"
+
+WORKDIR /work
+COPY requirements.txt /work
+RUN pip3 install -r requirements.txt
+
+RUN apt-get update && apt-get install -y \
+    software-properties-common
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
ローカル上でUnit Testを書く為に最低限動かしてエラーにならないテスト用のパスを追加。
なるべくサーバー上でのトラブルが無いように、この時点ではテスト以外ではなるべく同じコードになるようにしている。

UnitTest実行方法:

$ python sita.py unit_test

コマンドライン引数が一つで値がunit_testで無い限りはこれまで通りに振る舞うつもり。
だからこのままでdeployしても以前と同じ挙動のはず。

Dockerfileの使い方:

イメージの作り方
- $ docker build -t raito/sitabot .

実行方法
- $ docker run -it --rm -v $(pwd):/work raito/sitabot bash