### PR TITLE
noitsuのdbの依存を切る

### DIFF
--- a/sita.py
+++ b/sita.py
@@ -4,6 +4,7 @@ from mastodon import Mastodon, StreamListener
 import os
 import re
 import datetime
+import unittest
 
 # firestore
 from google.cloud import firestore
@@ -173,8 +174,15 @@ def main(content, st, id):
         traceback.print_exc()
         return toot
 
+class TestHello(unittest.TestCase):
+    def test_hello(self):
+        self.assertEqual('hoge', 'hoge')
+
+
 def unit_test():
-    print("unit test")
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestHello)
+    runner = unittest.TextTestRunner()
+    runner.run(suite)
 
 if is_test:
     unit_test()

--- a/sita.py
+++ b/sita.py
@@ -20,15 +20,9 @@ def check_test():
 
 is_test = check_test()
 
-class MastodonMock:
-    pass
-
-class StoreMock:
-    pass
-
 def create_mastodon_client(test = False):
     if test:
-        return MastodonMock()
+        return {}
     else:
         CLIENT_ID = os.environ['CLIENT_ID']
         CLIENT_SECRET = os.environ['CLIENT_SECRET']
@@ -45,7 +39,7 @@ mastodon = create_mastodon_client(is_test)
 
 def create_db(test = False):
     if test:
-        return StoreMock()
+        return {}
     else:
         GCP_PROJECT_ID = os.environ['GCP_PROJECT_ID']
         return firestore.Client(project=GCP_PROJECT_ID)


### PR DESCRIPTION
- Storeというクラスを新設し、noitsuで使っているdb関連の処理をまとめた
- storeを引数で渡すようにDIするように変更する事で、UnitTestで別のMockを渡せるようにした
- 簡単なUnitTestを書いた

noitsuとadd_sitaでどちらもStoreを使うようにしないと中途半端ではあるが、
あまり大きなPRにしたくないのでnoitsuだけまずはdbへの依存を切った。
将来的にはadd_sita側も同様の変更を入れたい。